### PR TITLE
Explicitly set ts-jest diagnostics level

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,6 +1,6 @@
 require("nock").disableNetConnect();
 
-/** @type {import("ts-jest/dist/types").InitialOptionsTsJest} */
+/** @type {import("ts-jest").JestConfigWithTsJest} */
 module.exports = {
   clearMocks: true,
   moduleNameMapper: { "^(\\.{1,2}/.*)\\.js$": "$1" },
@@ -9,7 +9,15 @@ module.exports = {
   testEnvironment: "node",
   testMatch: ["**/*.test.ts"],
   testRunner: "jest-circus/runner",
-  transform: { "^.+\\.ts$": ["ts-jest", { useESM: true }] },
+  transform: {
+    "^.+\\.ts$": [
+      "ts-jest",
+      {
+        diagnostics: true,
+        useESM: true,
+      },
+    ],
+  },
   verbose: true,
 };
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc --project ./tsconfig.build.json",
-    "clean": "rimraf coverage && rimraf dist && rimraf lib",
+    "clean": "rimraf coverage dist lib",
     "eslint": "eslint . --ext .js,.cjs,.ts",
     "eslint:fix": "npm run eslint -- --fix",
     "lint": "tsc --noEmit && npm run eslint",


### PR DESCRIPTION
When this isn't set at least 1 test fails locally, but being explicit cause them to all pass.